### PR TITLE
Use multi-test runs with completed events

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -187,8 +187,7 @@ export class CSharpAdapter implements TestAdapter {
 
 
     cancel(): void {
-        // in a "real" TestAdapter this would kill the child process for the current test run (if there is any)
-        throw new Error("Method not implemented.");
+        this.log.error("Cancellation is not currently supported.");
     }
 
     dispose(): void {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -658,6 +658,9 @@ export namespace V2 {
         Message: string;
     }
 
+    export interface TestCompletedEvent extends DotNetTestResult {
+    }
+
     export interface BlockStructureRequest {
         FileName: string;
     }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,7 @@
+
+export function groupBy<T extends Record<TKey, string>, TKey extends string>(array: T[], key: TKey) : { [key: string]: T[] } {
+    return array.reduce((rv, x) => {
+        (rv[x[key]] = rv[x[key]] || []).push(x);
+        return rv;
+    }, <{ [key: string]: T[] }>({}));
+};


### PR DESCRIPTION
Added
1. Run multiple tests with a single request, to speed up L0s
2. Project filter glob settings, to speed up discovery